### PR TITLE
Switch to platform independent line endings

### DIFF
--- a/ItemSwap.cs
+++ b/ItemSwap.cs
@@ -29,7 +29,7 @@ namespace MMRando
         {
             GetItemIndices = new List<int>();
             BottleIndices = new List<int[]>();
-            string[] lines = Properties.Resources.ITEM_INDICES.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            string[] lines = Properties.Resources.ITEM_INDICES.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             int i = 0;
             bool bottle = false;
             while (i < lines.Length)

--- a/Shuffle.cs
+++ b/Shuffle.cs
@@ -100,7 +100,7 @@ namespace MMRando
         {
             GossipList = new List<Gossip>();
             GossipQuotes = new List<string>();
-            string[] lines = Properties.Resources.GOSSIP.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            string[] lines = Properties.Resources.GOSSIP.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             int i = 0;
             while (i < lines.Length)
             {
@@ -205,7 +205,7 @@ namespace MMRando
         {
             SeqList = new List<SeqInfo>();
             TargetSeqs = new List<SeqInfo>();
-            string[] lines = Properties.Resources.SEQS.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            string[] lines = Properties.Resources.SEQS.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             int i = 0;
             while (i < lines.Length)
             {
@@ -368,16 +368,16 @@ namespace MMRando
             string[] lines;
             if (cMode.SelectedIndex == 0)
             {
-                lines = Properties.Resources.REQ_CASUAL.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                lines = Properties.Resources.REQ_CASUAL.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             }
             else if (cMode.SelectedIndex == 1)
             {
-                lines = Properties.Resources.REQ_GLITCH.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                lines = Properties.Resources.REQ_GLITCH.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
             }
             else if (cMode.SelectedIndex == 3)
             {
                 StreamReader Req = new StreamReader(File.Open(openLogic.FileName, FileMode.Open));
-                lines = Req.ReadToEnd().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                lines = Req.ReadToEnd().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
                 Req.Close();
             }
             else

--- a/fLogicEdit.cs
+++ b/fLogicEdit.cs
@@ -270,7 +270,7 @@ namespace MMRando
             {
                 StreamReader LogicFile = new StreamReader(File.Open(openLogic.FileName, FileMode.Open));
                 ItemList = new List<ItemLogic>();
-                string[] lines = LogicFile.ReadToEnd().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                string[] lines = LogicFile.ReadToEnd().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
                 int i = 0;
                 while (true)
                 {


### PR DESCRIPTION
These resource strings are encoded with Unix style line endings, as a result if you build the randomizer in Windows these split statements will not work properly since `Environement.NewLine` will be `\r\n`, and it will read these resources as one big line.

This presents itself as index out of bounds exceptions whenever one of the lists that are updated with values from these is accessed, such as `ItemList`.